### PR TITLE
Refactor: Primitives for TypeScript types and type declarations.

### DIFF
--- a/typescript/typescript.go
+++ b/typescript/typescript.go
@@ -1,0 +1,340 @@
+// Package typescript provides primitives to represent TypeScript types, and type declarations.
+//
+// This package is completely decoupled from Go's reflect package. It provides a set of very simple
+// primitives to build an AST-like representation of TypeScript types, and type declarations. Each
+// primitive includes a ToTypeScript() method that can be used to recursively generate Go2TS's
+// output TypeScript code.
+//
+// These primitives decouple Go2TS's reflection code from its code generation code, which makes
+// Go2TS easier to debug and reason about, and provide a flexible foundation that will allow us to
+// extend Go2TS in the future with support for additional types, new features, etc.
+//
+// The "root" type in this package is the TypeDeclaration interface, which is implemented by the
+// InterfaceDeclaration and TypeAliasDeclaration structs.
+//
+// The names of the primitives in this package are loosely based on the names and terms used in the
+// TypeScript AST. Recommended links:
+//   - https://ts-ast-viewer.com/
+//   - https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
+package typescript
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Type represents a TypeScript type.
+type Type interface {
+	// ToTypeScript returns a TypeScript expression that can be used as a type, or panics if the type
+	// is invalid.
+	ToTypeScript() string
+
+	isType()
+}
+
+///////////////
+// BasicType //
+///////////////
+
+// BasicType represents a TypeScript basic type supported by Go2TS.
+//
+// The "null" and "any" types are represented as basic types for simplicity.
+type BasicType string
+
+const (
+	// Boolean represents the "boolean" TypeScript type.
+	Boolean = BasicType("boolean")
+
+	// Number represents the "number" TypeScript type.
+	Number = BasicType("number")
+
+	// String represents the "string" TypeScript type.
+	String = BasicType("string")
+
+	// Null represents the "null" TypeScript type.
+	Null = BasicType("null")
+
+	// Any represents the "null" TypeScript type.
+	Any = BasicType("any")
+)
+
+// ToTypeScript implements the Type interface.
+func (b BasicType) ToTypeScript() string { return string(b) }
+
+// isType implements the Type interface.
+func (b BasicType) isType() {}
+
+var _ Type = (*BasicType)(nil)
+
+/////////////////
+// LiteralType //
+/////////////////
+
+// LiteralType represents a TypeScript literal type such as "hello", 123, true, etc.
+//
+// See https://www.typescriptlang.org/docs/handbook/literal-types.html.
+type LiteralType struct {
+	BasicType BasicType
+	Literal   string
+}
+
+// ToTypeScript implements the Type interface.
+func (l *LiteralType) ToTypeScript() string {
+	switch l.BasicType {
+	case Boolean:
+		if l.Literal != "true" && l.Literal != "false" {
+			panic(fmt.Sprintf(`Invalid boolean literal: %q`, l.Literal))
+		}
+		return l.Literal
+	case Number:
+		return l.Literal
+	case String:
+		return fmt.Sprintf(`"%s"`, l.Literal)
+	}
+	panic(fmt.Sprintf(`Invalid basic type: %q`, l.BasicType))
+}
+
+// isType implements the Type interface.
+func (l *LiteralType) isType() {}
+
+var _ Type = (*LiteralType)(nil)
+
+///////////////
+// ArrayType //
+///////////////
+
+// ArrayType represents a TypeScript array type such as string[], MyType[], etc.
+type ArrayType struct {
+	ItemsType Type
+}
+
+// ToTypeScript implements the Type interface.
+func (a *ArrayType) ToTypeScript() string {
+	fmtStr := "%s[]"
+	if _, ok := a.ItemsType.(*UnionType); ok {
+		fmtStr = "(%s)[]"
+	}
+	return fmt.Sprintf(fmtStr, a.ItemsType.ToTypeScript())
+}
+
+// isType implements the Type interface.
+func (a *ArrayType) isType() {}
+
+var _ Type = (*ArrayType)(nil)
+
+/////////////
+// MapType //
+/////////////
+
+// MapType represents a TypeScript type that describes an object used as a dictionary of key/value
+// pairs, e.g. { [key: string]: MyStruct }.
+type MapType struct {
+	IndexType Type
+	ValueType Type
+}
+
+// ToTypeScript implements the Type interface.
+func (m *MapType) ToTypeScript() string {
+	indexTypeToTS := m.IndexType.ToTypeScript()
+	if indexTypeToTS != "number" && indexTypeToTS != "string" {
+		panic(fmt.Sprintf("TypeScript type %q cannot be used as an index signature parameter type.", indexTypeToTS))
+	}
+
+	return fmt.Sprintf("{ [key: %s]: %s }", indexTypeToTS, m.ValueType.ToTypeScript())
+}
+
+// isType implements the Type interface.
+func (m *MapType) isType() {}
+
+var _ Type = (*MapType)(nil)
+
+///////////////
+// UnionType //
+///////////////
+
+// UnionType represents a TypeScript union type, e.g. 'up' | 'right' | 'down' | 'left'.
+type UnionType struct {
+	Types []Type
+}
+
+// ToTypeScript implements the Type interface.
+func (u UnionType) ToTypeScript() string {
+	tsTypes := []string{}
+	for _, t := range u.Types {
+		tsTypes = append(tsTypes, t.ToTypeScript())
+	}
+	return strings.Join(tsTypes, " | ")
+}
+
+// isType implements the Type interface.
+func (u UnionType) isType() {}
+
+var _ Type = (*UnionType)(nil)
+
+///////////////////
+// TypeReference //
+///////////////////
+
+// TypeReference represents a reference to a type declared via a TypeDeclaration (e.g. an interface,
+// a type alias, etc.) and can be used anywhere a Type can be used.
+type TypeReference struct {
+	typeDeclaration TypeDeclaration
+}
+
+// ToTypeScript implements the Type interface.
+func (t *TypeReference) ToTypeScript() string {
+	return t.typeDeclaration.QualifiedName()
+}
+
+// isType implements the Type interface.
+func (t *TypeReference) isType() {}
+
+var _ Type = (*TypeReference)(nil)
+
+/////////////////////
+// TypeDeclaration //
+/////////////////////
+
+// TypeDeclaration represents a TypeScript type declaration, which can be an interface declaration,
+// a type alias, etc.
+type TypeDeclaration interface {
+	// TypeReference returns a reference to the declared type.
+	TypeReference() *TypeReference
+
+	// QualifiedName returns the qualified name of the declared type, e.g. MyNamespace.MyType.
+	QualifiedName() string
+
+	// ToTypeScript converts the TypeDeclaration to valid TypeScript.
+	ToTypeScript() string
+
+	isTypeDeclaration()
+}
+
+//////////////////////////
+// TypeAliasDeclaration //
+//////////////////////////
+
+// TypeAliasDeclaration represents a TypeScript type alias declaration, e.g. type Color = string.
+type TypeAliasDeclaration struct {
+	// Namespace is the namespace that the type alias belongs to, or empty for the global namespace.
+	Namespace  string
+	Identifier string
+	Type       Type
+}
+
+// TypeReference implements the TypeDeclaration interface.
+func (a *TypeAliasDeclaration) TypeReference() *TypeReference {
+	return &TypeReference{
+		typeDeclaration: a,
+	}
+}
+
+// QualifiedName implements the TypeDeclaration interface.
+func (a *TypeAliasDeclaration) QualifiedName() string {
+	return makeQualifiedName(a.Namespace, a.Identifier)
+}
+
+// ToTypeScript implements the TypeDeclaration interface.
+func (a *TypeAliasDeclaration) ToTypeScript() string {
+	if a.Namespace == "" {
+		return fmt.Sprintf("export type %s = %s;", a.Identifier, a.Type.ToTypeScript())
+	}
+	return fmt.Sprintf("export namespace %s { export type %s = %s; }", a.Namespace, a.Identifier, a.Type.ToTypeScript())
+}
+
+// isTypeDeclaration implements the TypeDeclaration interface.
+func (a *TypeAliasDeclaration) isTypeDeclaration() {}
+
+var _ TypeDeclaration = (*TypeAliasDeclaration)(nil)
+
+//////////////////////////
+// InterfaceDeclaration //
+//////////////////////////
+
+// PropertySignature represents a property signature of a TypeScript interface declaration.
+type PropertySignature struct {
+	Identifier string
+	Type       Type
+	Optional   bool
+}
+
+// ToTypeScript converts the PropertySignature to a valid TypeScript interface property declaration.
+func (p *PropertySignature) ToTypeScript() string {
+	optionalString := ""
+	if p.Optional {
+		optionalString = "?"
+	}
+	return fmt.Sprintf("%s%s: %s;", p.Identifier, optionalString, p.Type.ToTypeScript())
+}
+
+// InterfaceDeclaration represents a TypeScript interface declaration.
+type InterfaceDeclaration struct {
+	// Namespace is the namespace that the interface belongs to, or empty for the global namespace.
+	Namespace  string
+	Identifier string
+	Properties []PropertySignature
+}
+
+// TypeReference implements the TypeDeclaration interface.
+func (i *InterfaceDeclaration) TypeReference() *TypeReference {
+	return &TypeReference{
+		typeDeclaration: i,
+	}
+}
+
+// QualifiedName implements the TypeDeclaration interface.
+func (i *InterfaceDeclaration) QualifiedName() string {
+	return makeQualifiedName(i.Namespace, i.Identifier)
+}
+
+// ToTypeScript implements the TypeDeclaration interface.
+func (i *InterfaceDeclaration) ToTypeScript() string {
+	var sb strings.Builder
+
+	namespaced := i.Namespace != ""
+	interfaceIndentation := ""
+	propertyIndentation := "\t"
+
+	if namespaced {
+		sb.WriteString(fmt.Sprintf("export namespace %s {\n", i.Namespace))
+		interfaceIndentation = "\t"
+		propertyIndentation = "\t\t"
+	}
+
+	sb.WriteString(interfaceIndentation)
+	sb.WriteString(fmt.Sprintf("export interface %s {\n", i.Identifier))
+
+	for _, prop := range i.Properties {
+		sb.WriteString(propertyIndentation)
+		sb.WriteString(prop.ToTypeScript())
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString(interfaceIndentation)
+	sb.WriteString("}")
+
+	if namespaced {
+		sb.WriteString("\n}")
+	}
+
+	return sb.String()
+}
+
+// isTypeDeclaration implements the TypeDeclaration interface.
+func (i *InterfaceDeclaration) isTypeDeclaration() {}
+
+var _ TypeDeclaration = (*InterfaceDeclaration)(nil)
+
+///////////////////////
+// Utility functions //
+///////////////////////
+
+// makeQualifiedName returns a qualified TypeScript type name given a namespace and an identifier.
+// If the namespace is the empty string, the type is assumed to be declared in the global namespace.
+// Does not support nested namespaces.
+func makeQualifiedName(namespace, identifier string) string {
+	if namespace != "" {
+		return fmt.Sprintf("%s.%s", namespace, identifier)
+	}
+	return identifier
+}

--- a/typescript/typescript_test.go
+++ b/typescript/typescript_test.go
@@ -1,0 +1,159 @@
+package typescript
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicType_ToTypeScript_Success(t *testing.T) {
+	assert.Equal(t, "boolean", Boolean.ToTypeScript())
+	assert.Equal(t, "number", Number.ToTypeScript())
+	assert.Equal(t, "string", String.ToTypeScript())
+}
+
+func TestLiteralType_ToTypeScript_Success(t *testing.T) {
+	literalType := LiteralType{BasicType: Boolean, Literal: "true"}
+	assert.Equal(t, "true", literalType.ToTypeScript())
+
+	literalType = LiteralType{BasicType: Number, Literal: "123.45"}
+	assert.Equal(t, "123.45", literalType.ToTypeScript())
+
+	literalType = LiteralType{BasicType: String, Literal: "hello"}
+	assert.Equal(t, `"hello"`, literalType.ToTypeScript())
+}
+
+func TestLiteralType_ToTypeScript_InvalidLiteral_Panics(t *testing.T) {
+	assert.PanicsWithValue(t, `Invalid boolean literal: "maybe"`, func() {
+		literalType := LiteralType{BasicType: Boolean, Literal: "maybe"}
+		literalType.ToTypeScript()
+	})
+
+	assert.PanicsWithValue(t, `Invalid basic type: "faketype"`, func() {
+		literalType := LiteralType{BasicType: BasicType("faketype"), Literal: "hello"}
+		literalType.ToTypeScript()
+	})
+}
+
+func TestArrayType_ToTypeScript_Sucess(t *testing.T) {
+	arrayType := ArrayType{ItemsType: String}
+	assert.Equal(t, "string[]", arrayType.ToTypeScript())
+
+	arrayType = ArrayType{
+		ItemsType: &UnionType{
+			Types: []Type{String, Number},
+		},
+	}
+	assert.Equal(t, "(string | number)[]", arrayType.ToTypeScript())
+}
+
+func TestMapType_ToTypeScript_Success(t *testing.T) {
+	mapType := MapType{
+		IndexType: String,
+		ValueType: Number,
+	}
+	assert.Equal(t, "{ [key: string]: number }", mapType.ToTypeScript())
+}
+
+func TestMapType_ToTypeScript_InvalidIndexType_Panics(t *testing.T) {
+	assert.PanicsWithValue(t, `TypeScript type "boolean" cannot be used as an index signature parameter type.`, func() {
+		mapType := MapType{
+			IndexType: Boolean,
+			ValueType: Number,
+		}
+		mapType.ToTypeScript()
+	})
+}
+
+func TestUnionType_ToTypeScript_Success(t *testing.T) {
+	unionType := UnionType{
+		Types: []Type{
+			&LiteralType{BasicType: String, Literal: "up"},
+			&LiteralType{BasicType: String, Literal: "right"},
+			&LiteralType{BasicType: String, Literal: "down"},
+			&LiteralType{BasicType: String, Literal: "left"},
+		},
+	}
+	assert.Equal(t, `"up" | "right" | "down" | "left"`, unionType.ToTypeScript())
+}
+
+func TestTypeAliasDeclaration_ToTypeScript_Success(t *testing.T) {
+	unionType := UnionType{
+		Types: []Type{
+			&LiteralType{BasicType: String, Literal: "up"},
+			&LiteralType{BasicType: String, Literal: "right"},
+			&LiteralType{BasicType: String, Literal: "down"},
+			&LiteralType{BasicType: String, Literal: "left"},
+		},
+	}
+
+	typeAliasDeclaration := TypeAliasDeclaration{
+		Identifier: "Direction",
+		Type:       unionType,
+	}
+	assert.Equal(t, `export type Direction = "up" | "right" | "down" | "left";`, typeAliasDeclaration.ToTypeScript())
+
+	typeAliasDeclaration.Namespace = "Foo"
+	assert.Equal(t, `export namespace Foo { export type Direction = "up" | "right" | "down" | "left"; }`, typeAliasDeclaration.ToTypeScript())
+}
+
+func TestTypeAliasDeclaration_TypeReference_ReferenceReflectsChangesInDeclaration(t *testing.T) {
+	typeAliasDeclaration := TypeAliasDeclaration{
+		Identifier: "MyAlias",
+		Type:       String,
+	}
+
+	typeReference := typeAliasDeclaration.TypeReference()
+	assert.Equal(t, "MyAlias", typeReference.ToTypeScript())
+
+	typeAliasDeclaration.Namespace = "Foo"
+	assert.Equal(t, "Foo.MyAlias", typeReference.ToTypeScript())
+
+	typeAliasDeclaration.Identifier = "AnotherAlias"
+	assert.Equal(t, "Foo.AnotherAlias", typeReference.ToTypeScript())
+}
+
+func TestInterfaceDeclaration_ToTypeScript_Success(t *testing.T) {
+	interfaceDeclaration := InterfaceDeclaration{
+		Identifier: "Person",
+		Properties: []PropertySignature{
+			{
+				Identifier: "Name",
+				Type:       String,
+			},
+			{
+				Identifier: "Age",
+				Type:       Number,
+				Optional:   true,
+			},
+		},
+	}
+
+	assert.Equal(t, `export interface Person {
+	Name: string;
+	Age?: number;
+}`, interfaceDeclaration.ToTypeScript())
+
+	interfaceDeclaration.Namespace = "Foo"
+	assert.Equal(t, `export namespace Foo {
+	export interface Person {
+		Name: string;
+		Age?: number;
+	}
+}`, interfaceDeclaration.ToTypeScript())
+}
+
+func TestInterfaceDeclaration_TypeReference_ReferenceReflectsChangesInDeclaration(t *testing.T) {
+	interfaceDeclaration := InterfaceDeclaration{
+		Identifier: "MyInterface",
+	}
+
+	typeReference := interfaceDeclaration.TypeReference()
+	assert.Equal(t, "MyInterface", typeReference.ToTypeScript())
+
+	interfaceDeclaration.Namespace = "Foo"
+	assert.Equal(t, "Foo.MyInterface", typeReference.ToTypeScript())
+
+	interfaceDeclaration.Identifier = "AnotherInterface"
+	assert.Equal(t, "Foo.AnotherInterface", typeReference.ToTypeScript())
+}


### PR DESCRIPTION
This non-functional change refactors go2ts.go to facilitate implementing support for namespaces, which I do in https://github.com/skia-dev/go2ts/pull/15.

Currently we map `reflect.Type`s to TypeScript types via `reflect.Type.Name()`, but this ceases to work as soon as we prefix a TypeScript type with a namespace (e.g. `namespace.Foo` instead of just `Foo`). I tried to add support for namespaces in various ways while keeping the current mapping mechanism, but I either got stuck, or the result was messy. 

This PR replaces said mapping with a more general mechanism using very simple AST-like structs, which makes adding support for namespaces extremely easy (done in https://github.com/skia-dev/go2ts/pull/15). This change has the additional benefits of decoupling the reflection code from the code generation code, which makes go2ts.go easier to debug and reason about, and of making it potentially easier to add new features or support for additional types in the future.

Notes to reviewer:

- I recommend starting from typescript.go.
- The AST-like primitives in typescript.go already include support for namespaces, but we ignore that in go2ts.go for now.
- The changes in go2ts.go should be non-functional; note that go2ts_test.go didn't change.
- I kept intact as much of go2ts.go as I could to facilitate reviewing, but we might want to shuffle things around in a follow-up PR.

